### PR TITLE
Add default securityContext to deployment

### DIFF
--- a/charts/kove/templates/deployment.yaml
+++ b/charts/kove/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
       volumes:
         - name: config
           configMap:
@@ -94,3 +97,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    securityContext:
+      runAsNonRoot: true
+


### PR DESCRIPTION
The kove container already runs as a non root user so this just enforces running as non root via Kubernetes securityContexts. This is simply a nice to have for easy assurance that kove is in fact not running as root